### PR TITLE
Restore total trading result from cumulative session data

### DIFF
--- a/custom_components/frank_energie_slim/api.py
+++ b/custom_components/frank_energie_slim/api.py
@@ -144,14 +144,26 @@ class FrankEnergie:
             node = ((resp.get("data") or {}).get("smartBatterySessions") or {})
             sessions = node.get("sessions") or []
             if isinstance(sessions, list):
+                total_trading_result = node.get("totalTradingResult")
                 for s in sessions:
+                    if not isinstance(s, dict):
+                        continue
                     if "cumulativeTradingResult" not in s and "cumulativeResult" in s:
                         s["cumulativeTradingResult"] = s["cumulativeResult"]
                     if "tradingResult" not in s and "result" in s:
                         s["tradingResult"] = s["result"]
+                    if total_trading_result is None:
+                        cumulative = s.get("cumulativeTradingResult")
+                        if cumulative is not None:
+                            total_trading_result = cumulative
+                if total_trading_result is not None:
+                    try:
+                        node["totalTradingResult"] = float(total_trading_result)
+                    except (TypeError, ValueError):
+                        node["totalTradingResult"] = total_trading_result
         except Exception:
             pass
-    
+
         return resp
 
     def is_authenticated(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,12 +87,16 @@ class TestFrankEnergie(unittest.TestCase):
                         "periodTradingResult": 3.0,
                         "sessions": [
                             {
-                                "cumulativeTradingResult": 3.0,
+                                "cumulativeResult": 3.0,
                                 "date": "2025-04-01",
-                                "tradingResult": 3.0
+                                "result": 3.0
+                            },
+                            {
+                                "cumulativeResult": 17.0,
+                                "date": "2025-04-10",
+                                "result": 14.0
                             }
-                        ],
-                        "totalTradingResult": 17.0
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- derive a battery's totalTradingResult from the cumulative session data returned by the API
- keep backward compatibility for per-session result fields when GraphQL names change
- extend the API unit test to cover cumulativeResult-only responses

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests', 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68d0523235b883209a5f4351a0b03b3e